### PR TITLE
Revert "fix: Have bazel steward sequentially scan directories"

### DIFF
--- a/.github/workflows/bazel-steward.yml
+++ b/.github/workflows/bazel-steward.yml
@@ -8,6 +8,11 @@ on:
 
 jobs:
   bazel-steward:
+    strategy:
+      matrix:
+        workspace-root:
+          - "."
+          - "examples"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -19,13 +24,8 @@ jobs:
         with:
           app-id: ${{ secrets.BAZEL_STEWARD_APP_ID }}
           private-key: ${{ secrets.BAZEL_STEWARD_APP_PRIVATE_KEY }}
-      - name: Scan root workspace
-        uses: VirtusLab/bazel-steward@v1.5.0
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-      - name: Scan example workspace
-        uses: VirtusLab/bazel-steward@v1.5.0
+      - uses: VirtusLab/bazel-steward@v1.5.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           # Workaround for multiple workspaces (cf. https://github.com/VirtusLab/bazel-steward/issues/40)
-          additional-args: examples
+          additional-args: ${{ matrix.workspace-root }}


### PR DESCRIPTION
This reverts commit 2a24b7de4f1e1fb3fd2dd8f798ae0ed0d96c5241.

Because of [this error](https://github.com/yuyawk/rules_build_error/actions/runs/8934564222/job/24541659535)