### PR TITLE
Updated bazel_skylib to 1.7.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ module(
 #
 ################################
 
-bazel_dep(name = "bazel_skylib", version = "1.6.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.7.0", dev_dependency = True)
 bazel_dep(
     name = "hermetic_cc_toolchain",
     version = "3.1.0",


### PR DESCRIPTION
https://github.com/yuyawk/rules_build_error/pull/48 with a correct branch name