### PR TITLE
fix: take `conlyopts` into consideration

### DIFF
--- a/lang/cc/build_error.bzl
+++ b/lang/cc/build_error.bzl
@@ -109,6 +109,8 @@ def _try_compile(ctx):
     ccopts = ctx.fragments.cpp.copts + ctx.attr.copts
     if _is_cpp(ctx.file.src):
         ccopts += ctx.fragments.cpp.cxxopts
+    elif _is_c(ctx.file.src):
+        ccopts += ctx.fragments.cpp.conlyopts
 
     compile_variables = cc_common.create_compile_variables(
         cc_toolchain = cc_toolchain,


### PR DESCRIPTION
https://bazel.build/rules/lib/fragments/cpp#conlyopts