### PR TITLE
chore: add `config_settings` to remove deprecated dependency

### DIFF
--- a/config_settings/BUILD.bazel
+++ b/config_settings/BUILD.bazel
@@ -1,13 +1,18 @@
+# Configuration setting that matches when the host CPU is x64 running on Windows.
 config_setting(
     name = "host_windows_x64_constraint",
     values = {"host_cpu": "x64_windows"},
 )
 
+# Configuration setting that matches when the host CPU is ARM64 running on Windows.
 config_setting(
     name = "host_windows_arm64_constraint",
     values = {"host_cpu": "arm64_windows"},
 )
 
+# Alias that selects the appropriate host constraint based on the detected host CPU.
+# Defaults to x64 if the ARM64 constraint does not match.
+# This alias can be used by other rules or macros to uniformly reference the host platform constraint.
 alias(
     name = "host_windows",
     actual = select({

--- a/config_settings/BUILD.bazel
+++ b/config_settings/BUILD.bazel
@@ -1,0 +1,18 @@
+config_setting(
+    name = "host_windows_x64_constraint",
+    values = {"host_cpu": "x64_windows"},
+)
+
+config_setting(
+    name = "host_windows_arm64_constraint",
+    values = {"host_cpu": "arm64_windows"},
+)
+
+alias(
+    name = "host_windows",
+    actual = select({
+        ":host_windows_arm64_constraint": ":host_windows_arm64_constraint",
+        "//conditions:default": ":host_windows_x64_constraint",
+    }),
+    visibility = ["//lang:__subpackages__"],
+)

--- a/lang/cc/build_error.bzl
+++ b/lang/cc/build_error.bzl
@@ -745,7 +745,7 @@ def cc_build_error_test(*, name, **kwargs):
         name = name,
         cc_build_error = ":" + build_target_name,
         is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
+            str(Label("//config_settings:host_windows")): True,
             "//conditions:default": False,
         }),
         tags = tags,


### PR DESCRIPTION
To get rid of the deprecation warning
```
WARNING: /Users/runner/work/rules_build_error/rules_build_error/tests/cc/c_link_error_with_deps/BUILD.bazel:12:21: in _create_test rule //tests/cc/c_link_error_with_deps:plain.test: target '//tests/cc/c_link_error_with_deps:plain.test' depends on deprecated target '@@bazel_tools//src/conditions:host_windows_x64_constraint': No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.
```